### PR TITLE
Create and delete a group

### DIFF
--- a/example.php
+++ b/example.php
@@ -24,7 +24,7 @@ $catId = $r->apiresult->category->id;
 
 // create a topic
 $r = $api->createTopic(
-    'This is the title of a brand new topic', 
+    'This is the title of a brand new topic',
     "This is the body text of a brand new topic. I really don't know what to say",
     $catId,
     "johndoe"
@@ -36,14 +36,11 @@ $topicId = $r->apiresult->id;
 $r = $api->createPost(
     'This is the body of a new post in an existing topic',
     $topicId,
-    $catId,
     'johndoe'
 );
-    
+
 // change sitesetting
 // use 'true' and 'false' between quotes
 
 $r = $api->changeSiteSetting('invite_expiry_days', 29);
 print_r($r);
-
-

--- a/lib/DiscourseAPI.php
+++ b/lib/DiscourseAPI.php
@@ -36,8 +36,6 @@ class DiscourseAPI
         if ($paramArray == null) {
             $paramArray = array();
         }
-        $paramArray['api_key'] = $this->_apiKey;
-        $paramArray['api_username'] = $apiUser;
         $ch = curl_init();
         $url = sprintf(
             '%s://%s%s?%s',
@@ -46,7 +44,12 @@ class DiscourseAPI
             $reqString, 
             http_build_query($paramArray)
         );
-	    
+
+    	curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            "Api-Key: " . $this->_apiKey,
+            "Api-Username: $apiUser"
+        ]);
+    
 	if (!empty($this->_httpAuthName) && !empty($this->_httpAuthPass)) {
             curl_setopt($ch, CURLOPT_USERPWD, $this->_httpAuthName . ":" . $this->_httpAuthPass);
             curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);

--- a/lib/DiscourseAPI.php
+++ b/lib/DiscourseAPI.php
@@ -1,18 +1,18 @@
 <?php
 
 /**
-  * Discourse API client for PHP
-  *
-  * This is the Discourse API client for PHP
-  * This is a very experimental API implementation.
-  *
-  * @category  DiscourseAPI
-  * @package   DiscourseAPI
-  * @author    Original author DiscourseHosting <richard@discoursehosting.com>
-  * @copyright 2013, DiscourseHosting.com
-  * @license   http://www.gnu.org/licenses/gpl-2.0.html GPLv2 
-  * @link      https://github.com/discoursehosting/discourse-api-php
-  */
+ * Discourse API client for PHP
+ *
+ * This is the Discourse API client for PHP
+ * This is a very experimental API implementation.
+ *
+ * @category  DiscourseAPI
+ * @package   DiscourseAPI
+ * @author    Original author DiscourseHosting <richard@discoursehosting.com>
+ * @copyright 2013, DiscourseHosting.com
+ * @license   http://www.gnu.org/licenses/gpl-2.0.html GPLv2 
+ * @link      https://github.com/discoursehosting/discourse-api-php
+ */
 
 class DiscourseAPI
 {
@@ -22,11 +22,11 @@ class DiscourseAPI
     private $_httpAuthName = '';
     private $_httpAuthPass = '';
 
-    function __construct($dcHostname, $apiKey = null, $protocol='http', $httpAuthName='', $httpAuthPass='')
+    function __construct($dcHostname, $apiKey = null, $protocol = 'http', $httpAuthName = '', $httpAuthPass = '')
     {
         $this->_dcHostname = $dcHostname;
         $this->_apiKey = $apiKey;
-        $this->_protocol=$protocol;
+        $this->_protocol = $protocol;
         $this->_httpAuthName = $httpAuthName;
         $this->_httpAuthPass = $httpAuthPass;
     }
@@ -39,18 +39,18 @@ class DiscourseAPI
         $ch = curl_init();
         $url = sprintf(
             '%s://%s%s?%s',
-            $this->_protocol, 
-            $this->_dcHostname, 
-            $reqString, 
+            $this->_protocol,
+            $this->_dcHostname,
+            $reqString,
             http_build_query($paramArray)
         );
 
-    	curl_setopt($ch, CURLOPT_HTTPHEADER, [
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
             "Api-Key: " . $this->_apiKey,
             "Api-Username: $apiUser"
         ]);
-    
-	if (!empty($this->_httpAuthName) && !empty($this->_httpAuthPass)) {
+
+        if (!empty($this->_httpAuthName) && !empty($this->_httpAuthPass)) {
             curl_setopt($ch, CURLOPT_USERPWD, $this->_httpAuthName . ":" . $this->_httpAuthPass);
             curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         }
@@ -74,28 +74,32 @@ class DiscourseAPI
 
     private function _postRequest($reqString, $paramArray, $apiUser = 'system')
     {
+
         return $this->_putpostRequest($reqString, $paramArray, $apiUser, false);
     }
 
     private function _putpostRequest($reqString, $paramArray, $apiUser = 'system', $putMethod = false)
     {
+
         $ch = curl_init();
         $url = sprintf(
             '%s://%s%s?api_key=%s&api_username=%s',
-            $this->_protocol, 
-            $this->_dcHostname, 
-            $reqString, 
-            $this->_apiKey, 
+            $this->_protocol,
+            $this->_dcHostname,
+            $reqString,
+            $this->_apiKey,
             $apiUser
         );
+
+
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($paramArray));
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         if ($putMethod) {
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "PUT");
         }
-	    
-	if (!empty($this->_httpAuthName) && !empty($this->_httpAuthPass)) {
+
+        if (!empty($this->_httpAuthName) && !empty($this->_httpAuthPass)) {
             curl_setopt($ch, CURLOPT_USERPWD, $this->_httpAuthName . ":" . $this->_httpAuthPass);
             curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
         }
@@ -126,8 +130,8 @@ class DiscourseAPI
             return false;
         }
 
-        foreach($obj->apiresult as $group) {
-            if($group->name === $groupname) {
+        foreach ($obj->apiresult as $group) {
+            if ($group->name === $groupname) {
                 $groupId = $group->id;
                 break;
             }
@@ -141,7 +145,7 @@ class DiscourseAPI
             )
         );
 
-        if($groupId) {
+        if ($groupId) {
             return $this->_putRequest('/admin/groups/' . $groupId, $params);
         } else {
             return $this->_postRequest('/admin/groups', $params);
@@ -214,19 +218,19 @@ class DiscourseAPI
         return $this->_putRequest("/admin/users/{$userId}/activate", array());
     }
 
-   /**
-    * suspendUser
-    *
-    * @param integer $userId      id of user to suspend
-    *
-    * @return mixed HTTP return code
-    */
+    /**
+     * suspendUser
+     *
+     * @param integer $userId      id of user to suspend
+     *
+     * @return mixed HTTP return code
+     */
 
     function suspendUser($userId)
     {
         return $this->_putRequest("/admin/users/{$userId}/suspend", array());
     }
-	
+
     /**
      * getUsernameByEmail
      *
@@ -237,19 +241,20 @@ class DiscourseAPI
 
     function getUsernameByEmail($email)
     {
-        $users = $this->_getRequest('/admin/users/list/active.json', 
-            [ 'filter' => $email, 'show_emails' => 'true' ] 
+        $users = $this->_getRequest(
+            '/admin/users/list/active.json',
+            ['filter' => $email, 'show_emails' => 'true']
         );
-        foreach($users->apiresult as $user) {
-            if($user->email === $email) {
+        foreach ($users->apiresult as $user) {
+            if ($user->email === $email) {
                 return $user->username;
             }
         }
-	
+
         return false;
     }
 
-     /**
+    /**
      * getUserByUsername
      *
      * @param string $userName     username of user
@@ -261,18 +266,18 @@ class DiscourseAPI
     {
         return $this->_getRequest("/users/{$userName}.json");
     }
-	
+
     /**
-	 * getUserByExternalID
-	 *
-	 * @param string $externalID     external id of sso user
-	 *
-	 * @return mixed HTTP return code and API return object
-	 */
-	function getUserByExternalID($externalID)
-	{
-		return $this->_getRequest("/users/by-external/{$externalID}.json");
-	}
+     * getUserByExternalID
+     *
+     * @param string $externalID     external id of sso user
+     *
+     * @return mixed HTTP return code and API return object
+     */
+    function getUserByExternalID($externalID)
+    {
+        return $this->_getRequest("/users/by-external/{$externalID}.json");
+    }
 
     /**
      * createCategory
@@ -307,7 +312,7 @@ class DiscourseAPI
      * @return mixed HTTP return code and API return object
      */
 
-    function createTopic($topicTitle, $bodyText, $categoryId, $userName, $replyToId = 0) 
+    function createTopic($topicTitle, $bodyText, $categoryId, $userName, $replyToId = 0)
     {
         $params = array(
             'title' => $topicTitle,
@@ -318,7 +323,7 @@ class DiscourseAPI
         );
         return $this->_postRequest('/posts', $params, $userName);
     }
-	
+
     /**
      * watchTopic
      *
@@ -327,26 +332,28 @@ class DiscourseAPI
      * If no username is given, topic will be watched with
      * the system API username
      */
-     function watchTopic($topicId, $userName = 'system')
-     {
+    function watchTopic($topicId, $userName = 'system')
+    {
         $params = array(
-           'notification_level' => '3'
+            'notification_level' => '3'
         );
         return $this->_postRequest("/t/{$topicId}/notifications.json", $params, $userName);
-     }
+    }
 
     /**
      * createPost
      *
-     * NOT WORKING YET
+     * @param string $bodyText     body text of topic post
+     * @param string $topicId      topic id - must me a string not array
+     * @param string $userName     user to create topic as
+     *
+     * @return mixed HTTP return code and API return object
      */
 
-    function createPost($bodyText, $topicId, $categoryId, $userName)
+    function createPost($bodyText, $topicId, $userName)
     {
         $params = array(
             'raw' => $bodyText,
-            'archetype' => 'regular',
-            'category' => $categoryId,
             'topic_id' => $topicId
         );
         return $this->_postRequest('/posts', $params, $userName);
@@ -358,7 +365,7 @@ class DiscourseAPI
             'email' => $email,
             'topic_id' => $topicId
         );
-        return $this->_postRequest('/t/'.intval($topicId).'/invite.json', $params, $userName);
+        return $this->_postRequest('/t/' . intval($topicId) . '/invite.json', $params, $userName);
     }
 
     function changeSiteSetting($siteSetting, $value)
@@ -366,7 +373,7 @@ class DiscourseAPI
         $params = array($siteSetting => $value);
         return $this->_putRequest('/admin/site_settings/' . $siteSetting, $params);
     }
-    
+
     function getIDByEmail($email)
     {
         $username = $this->getUsernameByEmail($email);
@@ -383,10 +390,9 @@ class DiscourseAPI
         $params  = array('username_or_email' => $email);
         return $this->_postRequest('/admin/users/' . $user_id . '/log_out', $params);
     }
-	
-    function getUserinfoByName($username) 
+
+    function getUserinfoByName($username)
     {
         return $this->_getRequest("/users/{$username}.json");
     }
 }
-

--- a/lib/DiscourseAPI.php
+++ b/lib/DiscourseAPI.php
@@ -208,6 +208,24 @@ class DiscourseAPI
     }
 
     /**
+     * deleteGroup
+     *
+     * @param string $name         name of group to delete
+     *
+     * @return mixed HTTP return code and API return object
+     */
+
+    function deleteGroup($name)
+    {
+        $obj = $this->_getRequest('/groups/' . $name . '.json');
+        if ($obj->http_code != 200) {
+            return false;
+        }
+
+        return $this->_deleteRequest('/admin/groups/' . $obj->apiresult->group->id . '.json');
+    }
+
+    /**
      * getGroups
      *
      * @return mixed HTTP return code and API return object

--- a/lib/DiscourseAPI.php
+++ b/lib/DiscourseAPI.php
@@ -45,6 +45,7 @@ class DiscourseAPI
             http_build_query($paramArray)
         );
 
+        // TODO: move post requests to this auth also
         curl_setopt($ch, CURLOPT_HTTPHEADER, [
             "Api-Key: " . $this->_apiKey,
             "Api-Username: $apiUser"
@@ -90,7 +91,6 @@ class DiscourseAPI
             $this->_apiKey,
             $apiUser
         );
-
 
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($paramArray));
@@ -301,6 +301,18 @@ class DiscourseAPI
     }
 
     /**
+     * getTopic
+     *
+     * @param string $topicId   id of topic
+     *
+     * @return mixed HTTP return code and API return object
+     */
+    function getTopic($topicID)
+    {
+        return $this->_getRequest('/t/' . $topicID . '.json');
+    }
+
+    /**
      * createTopic
      *
      * @param string $topicTitle   title of topic
@@ -311,7 +323,6 @@ class DiscourseAPI
      *
      * @return mixed HTTP return code and API return object
      */
-
     function createTopic($topicTitle, $bodyText, $categoryId, $userName, $replyToId = 0)
     {
         $params = array(
@@ -349,7 +360,6 @@ class DiscourseAPI
      *
      * @return mixed HTTP return code and API return object
      */
-
     function createPost($bodyText, $topicId, $userName)
     {
         $params = array(

--- a/lib/DiscourseAPI.php
+++ b/lib/DiscourseAPI.php
@@ -31,6 +31,44 @@ class DiscourseAPI
         $this->_httpAuthPass = $httpAuthPass;
     }
 
+    private function _deleteRequest($reqString, $paramArray = null, $apiUser = 'system')
+    {
+        return $this->_deletepostRequest($reqString, $paramArray, $apiUser, true);
+    }
+
+    private function _deletepostRequest($reqString, $paramArray = null, $apiUser = 'system', $putMethod = false)
+    {
+        $ch = curl_init();
+        $url = sprintf(
+            '%s://%s%s?api_key=%s&api_username=%s',
+            $this->_protocol, 
+            $this->_dcHostname, 
+            $reqString, 
+            $this->_apiKey, 
+            $apiUser
+        );
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($paramArray));
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        if ($putMethod) {
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
+        }
+        
+    if (!empty($this->_httpAuthName) && !empty($this->_httpAuthPass)) {
+            curl_setopt($ch, CURLOPT_USERPWD, $this->_httpAuthName . ":" . $this->_httpAuthPass);
+            curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        }
+
+        $body = curl_exec($ch);
+        $rc = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        $resObj = new \stdClass();
+        $resObj->http_code = $rc;
+        $resObj->apiresult = json_decode($body);
+        return $resObj;
+    }
+
     private function _getRequest($reqString, $paramArray = null, $apiUser = 'system')
     {
         if ($paramArray == null) {

--- a/lib/DiscourseAPI.php
+++ b/lib/DiscourseAPI.php
@@ -193,8 +193,8 @@ class DiscourseAPI
 
     function createGroup($name)
     {
-        $obj = $this->_getRequest('/admin/groups/' . $name . '.json');
-        if ($obj->http_code != 200) {
+        $obj = $this->_getRequest('/groups/' . $name . '.json');
+        if ($obj->http_code == 200) {
             return false;
         }
 

--- a/lib/DiscourseAPI.php
+++ b/lib/DiscourseAPI.php
@@ -146,6 +146,30 @@ class DiscourseAPI
     }
 
     /**
+     * createGroup
+     *
+     * @param string $name         name of new group
+     *
+     * @return mixed HTTP return code and API return object
+     */
+
+    function createGroup($name)
+    {
+        $obj = $this->_getRequest('/admin/groups/' . $name . '.json');
+        if ($obj->http_code != 200) {
+            return false;
+        }
+
+        $params = array(
+            'group' => array(
+                'name' => $name,
+            )
+        );
+
+        return $this->_postRequest('/admin/groups', $params);
+    }
+
+    /**
      * getGroups
      *
      * @return mixed HTTP return code and API return object

--- a/lib/DiscourseAPI.php
+++ b/lib/DiscourseAPI.php
@@ -215,6 +215,24 @@ class DiscourseAPI
     }
 
     /**
+     * deleteGroup
+     *
+     * @param string $name         name of group to delete
+     *
+     * @return mixed HTTP return code and API return object
+     */
+
+    function deleteGroup($name)
+    {
+        $obj = $this->_getRequest('/groups/' . $name . '.json');
+        if ($obj->http_code != 200) {
+            return false;
+        }
+
+        return $this->_deleteRequest('/admin/groups/' . $obj->apiresult->group->id . '.json');
+    }
+
+    /**
      * getGroups
      *
      * @return mixed HTTP return code and API return object

--- a/lib/DiscourseAPI.php
+++ b/lib/DiscourseAPI.php
@@ -200,8 +200,8 @@ class DiscourseAPI
 
     function createGroup($name)
     {
-        $obj = $this->_getRequest('/admin/groups/' . $name . '.json');
-        if ($obj->http_code != 200) {
+        $obj = $this->_getRequest('/groups/' . $name . '.json');
+        if ($obj->http_code == 200) {
             return false;
         }
 

--- a/lib/DiscourseAPI.php
+++ b/lib/DiscourseAPI.php
@@ -153,6 +153,30 @@ class DiscourseAPI
     }
 
     /**
+     * createGroup
+     *
+     * @param string $name         name of new group
+     *
+     * @return mixed HTTP return code and API return object
+     */
+
+    function createGroup($name)
+    {
+        $obj = $this->_getRequest('/admin/groups/' . $name . '.json');
+        if ($obj->http_code != 200) {
+            return false;
+        }
+
+        $params = array(
+            'group' => array(
+                'name' => $name,
+            )
+        );
+
+        return $this->_postRequest('/admin/groups', $params);
+    }
+
+    /**
      * getGroups
      *
      * @return mixed HTTP return code and API return object


### PR DESCRIPTION
Hi, I was working on adding a feature to our SSO plugin that syncs groups to Discourse, but found out that we need to have the group already be created before syncing a user's group membership when using the SSO API. I noticed that this library didn't have functions to create or delete groups so I added a couple functions: createGroup() and deleteGroup().